### PR TITLE
fix(deps): Helix Patch dependency bumps (2 packages)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3776,9 +3776,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -13598,9 +13598,9 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npm.taobao.org/vue/download/vue-2.6.11.tgz?cache=0&sync_timestamp=1580160165548&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue%2Fdownload%2Fvue-2.6.11.tgz",
-      "integrity": "sha1-dllNh31LEiNEBuhONSdcbVFBJcU="
+      "version": "3.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.0.0-alpha.0.tgz",
+      "integrity": "sha512-wgQ1r4LVNQFD+L5bczQvItT+8Cak0jsA9cRIxwlyh+kb1jr6L8UktueEuBSoYhvC/899kprBuaR1vZHRAh5CLg=="
     },
     "vue-class-component": {
       "version": "7.2.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "core-js": "^3.6.4",
     "register-service-worker": "^1.6.2",
-    "vue": "^2.6.11",
+    "vue": "^3.0.0-alpha.0",
     "vue-class-component": "^7.2.2",
     "vue-property-decorator": "^8.3.0",
     "vue-router": "^3.1.5",


### PR DESCRIPTION
Opened by **Helix Patch**.

Bump packages where Trivy reported a fixed version:

- `brace-expansion`: `1.1.11` → `5.0.9` (CVE-2026-13149, CVE-2026-14257, CVE-2026-69152, CVE-2026-33750, CVE-2025-5889)
- `vue`: `2.6.11` → `3.0.0-alpha.0` (CVE-2024-9506)

Please run your package manager install if the lockfile needs a refresh, then review CI.