### PR TITLE
fix(deps): Helix Patch dependency bumps (1 packages)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7178,12 +7178,14 @@
           "optional": true
         },
         "brace-expansion": {
-          "version": "1.1.11",
+          "version": "5.0.9",
           "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
-          }
+          },
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+          "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="
         },
         "chownr": {
           "version": "1.1.3",


### PR DESCRIPTION
Opened by **Helix Patch**.

Bump packages where Trivy reported a fixed version:

- `brace-expansion`: `1.1.11` → `5.0.9` (CVE-2026-13149, CVE-2026-14257, CVE-2026-69152, CVE-2026-33750, CVE-2025-5889)

Please run your package manager install if the lockfile needs a refresh, then review CI.